### PR TITLE
fix: change WaitComponent text output type from str to Message

### DIFF
--- a/components/logic/wait.py
+++ b/components/logic/wait.py
@@ -80,7 +80,7 @@ class WaitComponent(Component):
             self.log(f"Wait component failed: {str(e)}")
             return None
 
-    def get_text_output(self) -> str:
+    def get_text_output(self) -> Message:
         """Wait and return input data as text - no conversion."""
         input_data = self._perform_wait()
         if input_data is None:


### PR DESCRIPTION
## Problem
The `WaitComponent.get_text_output()` method was returning type `str`, which is not compatible with input types of other Langflow components that expect `Message` type.

## Solution
Changed the return type annotation from `str` to `Message` in the `get_text_output()` method signature.

## Testing
- Tested the component after the change
- Confirmed that the output is now correctly typed as `Message` and compatible with other component inputs